### PR TITLE
Add FastAPI dashboard for 25-year P/E visualizations

### DIFF
--- a/pe_dashboard/README.md
+++ b/pe_dashboard/README.md
@@ -1,0 +1,47 @@
+# P/E Ratio Dashboard
+
+This FastAPI application exposes an API and lightweight front-end for exploring the daily price-to-earnings (P/E) ratio of large-cap technology companies. P/E values are derived by pairing daily adjusted close prices from Yahoo Finance with trailing-twelve-month EPS built from quarterly earnings releases.
+
+## Features
+
+- Fetches 25 years of price history and quarterly EPS for the default ticker set (NVDA, MSFT, GOOG, AMZN, META, AVGO, ORCL, TLSA, AAPL).
+- Interactive client powered by Chart.js allows you to:
+  - Toggle individual companies on or off.
+  - Switch between a combined multi-series chart and individual charts for selected companies.
+  - Adjust the date window.
+- Backend caching to avoid redundant Yahoo Finance requests during a session.
+
+## Running locally
+
+1. Install dependencies (Python 3.10+ recommended):
+
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   pip install -r requirements.txt -r pe_dashboard/requirements.txt
+   ```
+
+2. Start the development server:
+
+   ```bash
+   uvicorn pe_dashboard.app:app --reload
+   ```
+
+3. Open <http://127.0.0.1:8000> in your browser to use the dashboard.
+
+> **Note:** The app relies on live requests to Yahoo Finance via `yfinance`. Ensure outbound HTTPS access is permitted from your environment. If you encounter rate limiting, reloading after a short pause typically resolves the issue.
+
+> Tesla is listed as `TLSA` in the UI to mirror the original request; the backend transparently maps the symbol to Yahoo Finance's `TSLA` ticker when fetching data.
+
+## Project structure
+
+```
+pe_dashboard/
+├── README.md
+├── app.py           # FastAPI application & routing
+├── pe_data.py       # Data retrieval and P/E computation helpers
+└── static/
+    ├── app.js       # Front-end logic & chart rendering
+    ├── index.html   # Client entry point
+    └── style.css    # Styling for the dashboard
+```

--- a/pe_dashboard/app.py
+++ b/pe_dashboard/app.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta
+from pathlib import Path
+from typing import Dict, List
+from fastapi import FastAPI, HTTPException, Query
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
+
+from .pe_data import DEFAULT_TICKERS, DataUnavailableError, compute_pe_timeseries
+
+
+def _parse_date(value: str | None, default: date) -> date:
+    if not value:
+        return default
+    try:
+        return datetime.strptime(value, "%Y-%m-%d").date()
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=f"Invalid date format: {value}. Use YYYY-MM-DD.") from exc
+
+
+app = FastAPI(
+    title="P/E Ratio Dashboard",
+    description="Daily price-to-earnings time series for selected equities.",
+    version="1.0.0",
+)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+static_dir = Path(__file__).parent / "static"
+app.mount("/static", StaticFiles(directory=static_dir), name="static")
+
+
+@app.get("/")
+def read_index() -> FileResponse:
+    """Serve the client application entry point."""
+    return FileResponse(static_dir / "index.html")
+
+
+@app.get("/api/pe")
+def pe_endpoint(
+    tickers: str = Query(
+        ",".join(DEFAULT_TICKERS),
+        description="Comma separated list of ticker symbols to include in the response.",
+    ),
+    start: str | None = Query(None, description="Start date in YYYY-MM-DD format."),
+    end: str | None = Query(None, description="End date in YYYY-MM-DD format."),
+) -> Dict[str, List[Dict[str, float]]]:
+    """Return the P/E ratio time series for the requested tickers."""
+
+    requested: List[str] = [symbol.strip().upper() for symbol in tickers.split(",") if symbol.strip()]
+    if not requested:
+        raise HTTPException(status_code=400, detail="At least one ticker symbol is required.")
+
+    today = date.today()
+    default_start = today - timedelta(days=365 * 25)
+
+    start_date = _parse_date(start, default_start)
+    end_date = _parse_date(end, today)
+
+    if start_date >= end_date:
+        raise HTTPException(status_code=400, detail="Start date must be before end date.")
+
+    try:
+        series = compute_pe_timeseries(requested, start_date, end_date)
+    except (ValueError, DataUnavailableError) as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except Exception as exc:  # pragma: no cover - surface unexpected issues gracefully
+        raise HTTPException(status_code=502, detail=f"Failed to retrieve data: {exc}") from exc
+
+    payload: Dict[str, List[Dict[str, float]]] = {}
+    for symbol, frame in series.items():
+        payload[symbol] = [
+            {"date": idx.strftime("%Y-%m-%d"), "pe": round(value, 4)}
+            for idx, value in frame.items()
+        ]
+
+    return payload

--- a/pe_dashboard/pe_data.py
+++ b/pe_dashboard/pe_data.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from datetime import date, timedelta
+from functools import lru_cache
+from typing import Dict, Iterable, List
+
+import pandas as pd
+import yfinance as yf
+
+DEFAULT_TICKERS: List[str] = [
+    "NVDA",
+    "MSFT",
+    "GOOG",
+    "AMZN",
+    "META",
+    "AVGO",
+    "ORCL",
+    "TLSA",
+    "AAPL",
+]
+
+TICKER_ALIASES = {
+    "TLSA": "TSLA",
+}
+
+
+class DataUnavailableError(RuntimeError):
+    """Raised when underlying market data cannot be retrieved."""
+
+
+@lru_cache(maxsize=32)
+def _download_price_history(symbol: str, start: date, end: date) -> pd.Series:
+    """Retrieve the adjusted close price history for a single symbol."""
+
+    history = yf.download(
+        symbol,
+        start=start.isoformat(),
+        end=(end + timedelta(days=1)).isoformat(),
+        progress=False,
+        auto_adjust=True,
+        threads=False,
+    )
+    if history.empty:
+        raise DataUnavailableError(f"No price history returned for {symbol}.")
+
+    price_column = "Adj Close" if "Adj Close" in history.columns else "Close"
+    series = history[price_column].copy()
+    series.index = pd.to_datetime(series.index).tz_localize(None)
+    return series
+
+
+@lru_cache(maxsize=32)
+def _download_earnings(symbol: str, end: date) -> pd.DataFrame:
+    """Load historical quarterly EPS actuals for a symbol."""
+
+    ticker = yf.Ticker(symbol)
+    earnings = ticker.get_earnings_dates(limit=200)
+    if earnings is None or earnings.empty:
+        raise DataUnavailableError(f"No earnings history returned for {symbol}.")
+
+    earnings = earnings.copy()
+    earnings.index = pd.to_datetime(earnings.index).tz_localize(None)
+    earnings = earnings[earnings.index <= pd.Timestamp(end)]
+
+    eps_column = next((col for col in earnings.columns if col.lower() == "epsactual"), None)
+    if eps_column is None:
+        raise DataUnavailableError(f"Earnings data for {symbol} does not contain EPS actuals.")
+
+    earnings = earnings[[eps_column]].rename(columns={eps_column: "eps_actual"})
+    earnings = earnings.dropna()
+    if earnings.empty:
+        raise DataUnavailableError(f"No EPS actuals available for {symbol}.")
+
+    earnings = earnings.sort_index()
+    earnings["ttm_eps"] = earnings["eps_actual"].rolling(window=4).sum()
+    earnings = earnings.dropna(subset=["ttm_eps"])
+    if earnings.empty:
+        raise DataUnavailableError(f"Insufficient EPS history to compute trailing twelve months for {symbol}.")
+
+    earnings = earnings[earnings["ttm_eps"] > 0]
+    if earnings.empty:
+        raise DataUnavailableError(f"Trailing EPS for {symbol} is non-positive, cannot compute P/E.")
+
+    return earnings[["ttm_eps"]]
+
+
+def compute_pe_timeseries(symbols: Iterable[str], start: date, end: date) -> Dict[str, pd.Series]:
+    """Compute the daily P/E ratio for each requested symbol."""
+
+    results: Dict[str, pd.Series] = {}
+    for raw_symbol in symbols:
+        symbol = TICKER_ALIASES.get(raw_symbol, raw_symbol)
+        price_history = _download_price_history(symbol, start, end)
+        earnings = _download_earnings(symbol, end)
+
+        ttm_eps = earnings["ttm_eps"]
+        ttm_eps = ttm_eps.reindex(price_history.index, method="ffill")
+        merged = pd.DataFrame({"price": price_history, "ttm_eps": ttm_eps})
+        mask = (merged.index >= pd.Timestamp(start)) & (merged.index <= pd.Timestamp(end))
+        merged = merged.loc[mask]
+        merged = merged.dropna(subset=["price", "ttm_eps"])
+        if merged.empty:
+            raise DataUnavailableError(f"Unable to align price and EPS history for {symbol}.")
+
+        pe = (merged["price"] / merged["ttm_eps"]).dropna().sort_index()
+        results[raw_symbol] = pe
+
+    return results

--- a/pe_dashboard/requirements.txt
+++ b/pe_dashboard/requirements.txt
@@ -1,0 +1,4 @@
+fastapi==0.115.6
+uvicorn[standard]==0.32.1
+yfinance==0.2.66
+pandas==2.3.3

--- a/pe_dashboard/static/app.js
+++ b/pe_dashboard/static/app.js
@@ -1,0 +1,275 @@
+const DEFAULT_TICKERS = ["NVDA", "MSFT", "GOOG", "AMZN", "META", "AVGO", "ORCL", "TLSA", "AAPL"];
+const COLOR_PALETTE = [
+  "#2563eb",
+  "#16a34a",
+  "#d946ef",
+  "#f97316",
+  "#facc15",
+  "#06b6d4",
+  "#f43f5e",
+  "#8b5cf6",
+  "#10b981",
+];
+const API_ROOT = "/api/pe";
+
+const state = {
+  selectedTickers: new Set(DEFAULT_TICKERS),
+  mode: "combined",
+  startDate: null,
+  endDate: null,
+  combinedChart: null,
+  individualCharts: new Map(),
+};
+
+function formatDate(date) {
+  return date.toISOString().slice(0, 10);
+}
+
+function initDateInputs() {
+  const startInput = document.getElementById("start-date");
+  const endInput = document.getElementById("end-date");
+  const today = new Date();
+  const defaultStart = new Date();
+  defaultStart.setFullYear(today.getFullYear() - 25);
+
+  startInput.value = formatDate(defaultStart);
+  endInput.value = formatDate(today);
+
+  state.startDate = startInput.value;
+  state.endDate = endInput.value;
+
+  startInput.addEventListener("change", (event) => {
+    state.startDate = event.target.value;
+  });
+  endInput.addEventListener("change", (event) => {
+    state.endDate = event.target.value;
+  });
+}
+
+function initTickerCheckboxes() {
+  const container = document.getElementById("ticker-checkboxes");
+  DEFAULT_TICKERS.forEach((ticker) => {
+    const label = document.createElement("label");
+    const checkbox = document.createElement("input");
+    checkbox.type = "checkbox";
+    checkbox.name = "ticker";
+    checkbox.value = ticker;
+    checkbox.checked = state.selectedTickers.has(ticker);
+    checkbox.addEventListener("change", (event) => {
+      if (event.target.checked) {
+        state.selectedTickers.add(ticker);
+      } else {
+        state.selectedTickers.delete(ticker);
+      }
+    });
+
+    label.appendChild(checkbox);
+    label.append(ticker);
+    container.appendChild(label);
+  });
+}
+
+function initModeSwitch() {
+  const form = document.getElementById("control-form");
+  form.addEventListener("change", (event) => {
+    if (event.target.name === "mode") {
+      state.mode = event.target.value;
+      renderMode();
+    }
+  });
+}
+
+function renderMode() {
+  const combined = document.getElementById("combined-chart-container");
+  const individual = document.getElementById("individual-charts");
+
+  if (state.mode === "combined") {
+    combined.style.display = "block";
+    individual.style.display = "none";
+  } else {
+    combined.style.display = "none";
+    individual.style.display = "grid";
+  }
+}
+
+async function fetchPeData() {
+  if (state.selectedTickers.size === 0) {
+    throw new Error("Please select at least one company.");
+  }
+
+  const params = new URLSearchParams({
+    tickers: Array.from(state.selectedTickers).join(","),
+    start: state.startDate,
+    end: state.endDate,
+  });
+
+  const response = await fetch(`${API_ROOT}?${params.toString()}`);
+  if (!response.ok) {
+    const errorBody = await response.json().catch(() => ({}));
+    const message = errorBody?.detail ?? response.statusText;
+    throw new Error(message || "Failed to fetch P/E data");
+  }
+
+  return response.json();
+}
+
+function buildCombinedChart(canvas, data) {
+  const labels = extractLabels(data);
+  const datasets = Object.entries(data).map(([ticker, values], index) => {
+    const color = COLOR_PALETTE[index % COLOR_PALETTE.length];
+    return {
+      label: ticker,
+      data: alignSeries(labels, values),
+      borderWidth: 2,
+      tension: 0.25,
+      borderColor: color,
+      backgroundColor: `${color}33`,
+      spanGaps: true,
+    };
+  });
+
+  if (state.combinedChart) {
+    state.combinedChart.destroy();
+  }
+
+  state.combinedChart = new Chart(canvas, {
+    type: "line",
+    data: { labels, datasets },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      interaction: { mode: "index", intersect: false },
+      scales: {
+        y: { title: { display: true, text: "P/E" } },
+        x: { title: { display: true, text: "Date" } },
+      },
+      plugins: {
+        legend: { position: "top" },
+        tooltip: {
+          callbacks: {
+            label: (ctx) => `${ctx.dataset.label}: ${ctx.parsed.y?.toFixed(2)}`,
+          },
+        },
+      },
+    },
+  });
+}
+
+function buildIndividualCharts(container, data) {
+  // Destroy existing charts
+  state.individualCharts.forEach((chart) => chart.destroy());
+  state.individualCharts.clear();
+  container.replaceChildren();
+
+  Object.entries(data).forEach(([ticker, values], index) => {
+    const wrapper = document.createElement("div");
+    wrapper.className = "individual-chart";
+
+    const title = document.createElement("h3");
+    title.textContent = ticker;
+
+    const canvas = document.createElement("canvas");
+    canvas.setAttribute("role", "img");
+    canvas.setAttribute("aria-label", `${ticker} P/E chart`);
+
+    wrapper.appendChild(title);
+    wrapper.appendChild(canvas);
+    container.appendChild(wrapper);
+
+    const labels = values.map((item) => item.date);
+    const dataset = values.map((item) => item.pe);
+
+    const color = COLOR_PALETTE[index % COLOR_PALETTE.length];
+    const chart = new Chart(canvas, {
+      type: "line",
+      data: {
+        labels,
+        datasets: [
+          {
+            label: ticker,
+            data: dataset,
+            borderWidth: 2,
+            tension: 0.25,
+            borderColor: color,
+            backgroundColor: `${color}33`,
+            spanGaps: true,
+          },
+        ],
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        scales: {
+          y: { title: { display: true, text: "P/E" } },
+          x: { title: { display: true, text: "Date" } },
+        },
+      },
+    });
+
+    state.individualCharts.set(ticker, chart);
+  });
+}
+
+function extractLabels(data) {
+  const labelSet = new Set();
+  Object.values(data).forEach((series) => {
+    series.forEach((point) => labelSet.add(point.date));
+  });
+  return Array.from(labelSet).sort();
+}
+
+function alignSeries(labels, series) {
+  const lookup = new Map(series.map((item) => [item.date, item.pe]));
+  return labels.map((label) => lookup.get(label) ?? null);
+}
+
+function displayError(message) {
+  const combinedContainer = document.getElementById("combined-chart-container");
+  const individualContainer = document.getElementById("individual-charts");
+
+  combinedContainer.innerHTML = `<canvas id="combined-chart" aria-label="Combined P/E chart" role="img"></canvas>`;
+  individualContainer.replaceChildren();
+
+  const target = state.mode === "combined" ? combinedContainer : individualContainer;
+  const errorElement = document.createElement("div");
+  errorElement.className = "error";
+  errorElement.textContent = message;
+  target.appendChild(errorElement);
+
+  if (state.combinedChart) {
+    state.combinedChart.destroy();
+    state.combinedChart = null;
+  }
+  state.individualCharts.forEach((chart) => chart.destroy());
+  state.individualCharts.clear();
+}
+
+async function handleSubmit(event) {
+  event.preventDefault();
+  const combinedCanvas = document.getElementById("combined-chart");
+  const individualContainer = document.getElementById("individual-charts");
+
+  try {
+    const data = await fetchPeData();
+    if (state.mode === "combined") {
+      buildCombinedChart(combinedCanvas, data);
+    } else {
+      buildIndividualCharts(individualContainer, data);
+    }
+  } catch (error) {
+    console.error(error);
+    displayError(error.message);
+  }
+}
+
+function init() {
+  initTickerCheckboxes();
+  initDateInputs();
+  initModeSwitch();
+  renderMode();
+  document.getElementById("control-form").addEventListener("submit", handleSubmit);
+  // Load initial data
+  document.getElementById("control-form").dispatchEvent(new Event("submit"));
+}
+
+window.addEventListener("DOMContentLoaded", init);

--- a/pe_dashboard/static/index.html
+++ b/pe_dashboard/static/index.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>P/E Ratio Dashboard</title>
+    <link rel="stylesheet" href="/static/style.css" />
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.7/dist/chart.umd.min.js" defer></script>
+    <script src="/static/app.js" type="module" defer></script>
+  </head>
+  <body>
+    <header class="page-header">
+      <h1>Daily Price-to-Earnings Dashboard</h1>
+      <p>Select companies and visualize their price-to-earnings ratios over time.</p>
+    </header>
+
+    <main class="layout">
+      <section class="controls">
+        <form id="control-form">
+          <fieldset>
+            <legend>Companies</legend>
+            <div class="checkbox-grid" id="ticker-checkboxes"></div>
+          </fieldset>
+
+          <fieldset class="date-range">
+            <legend>Date Range</legend>
+            <label>
+              Start
+              <input type="date" id="start-date" />
+            </label>
+            <label>
+              End
+              <input type="date" id="end-date" />
+            </label>
+          </fieldset>
+
+          <fieldset class="mode">
+            <legend>Chart Mode</legend>
+            <label><input type="radio" name="mode" value="combined" checked /> Combined</label>
+            <label><input type="radio" name="mode" value="individual" /> Individual</label>
+          </fieldset>
+
+          <button type="submit">Update chart</button>
+        </form>
+      </section>
+
+      <section class="charts">
+        <div class="chart-container" id="combined-chart-container">
+          <canvas id="combined-chart" aria-label="Combined P/E chart" role="img"></canvas>
+        </div>
+        <div id="individual-charts" class="individual-grid"></div>
+      </section>
+    </main>
+
+    <footer class="page-footer">
+      <p>
+        Data provided by Yahoo Finance via <code>yfinance</code>. Trailing twelve month EPS values are interpolated between quarterly
+        earnings releases.
+      </p>
+    </footer>
+  </body>
+</html>

--- a/pe_dashboard/static/style.css
+++ b/pe_dashboard/static/style.css
@@ -1,0 +1,170 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  line-height: 1.6;
+  font-size: 16px;
+  --accent: #2563eb;
+  --bg: #f5f7fa;
+  --fg: #111827;
+  --card: #ffffffcc;
+  --border: #d1d5db;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--fg);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.page-header,
+.page-footer {
+  padding: 1.5rem clamp(1rem, 5vw, 3rem);
+  background: rgba(37, 99, 235, 0.1);
+  border-bottom: 1px solid rgba(17, 24, 39, 0.05);
+}
+
+.page-header h1 {
+  margin: 0 0 0.5rem;
+  font-size: clamp(1.5rem, 4vw, 2.5rem);
+}
+
+.layout {
+  display: grid;
+  grid-template-columns: minmax(250px, 320px) 1fr;
+  gap: 1.5rem;
+  padding: clamp(1rem, 5vw, 3rem);
+  flex: 1;
+}
+
+.controls form {
+  display: grid;
+  gap: 1.25rem;
+  background: var(--card);
+  padding: 1.5rem;
+  border-radius: 0.75rem;
+  border: 1px solid var(--border);
+  box-shadow: 0 20px 45px -20px rgba(15, 23, 42, 0.35);
+}
+
+fieldset {
+  border: 1px solid var(--border);
+  border-radius: 0.75rem;
+  padding: 1rem;
+}
+
+legend {
+  padding: 0 0.5rem;
+  font-weight: 600;
+}
+
+.checkbox-grid {
+  display: grid;
+  gap: 0.35rem 0.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+}
+
+.checkbox-grid label {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.95rem;
+}
+
+.date-range {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.date-range label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.mode label {
+  display: inline-flex;
+  align-items: center;
+  margin-right: 1rem;
+  gap: 0.25rem;
+}
+
+button[type="submit"] {
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  border: none;
+  background: var(--accent);
+  color: white;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+button[type="submit"]:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 20px -12px rgba(37, 99, 235, 0.6);
+}
+
+.charts {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.chart-container {
+  background: var(--card);
+  padding: 1rem;
+  border-radius: 0.75rem;
+  border: 1px solid var(--border);
+  box-shadow: 0 12px 30px -15px rgba(15, 23, 42, 0.3);
+}
+
+.error {
+  padding: 1rem;
+  border-radius: 0.75rem;
+  background: rgba(244, 63, 94, 0.1);
+  border: 1px solid rgba(244, 63, 94, 0.35);
+  color: #b91c1c;
+  font-weight: 600;
+}
+
+.individual-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.5rem;
+}
+
+.individual-chart {
+  background: var(--card);
+  padding: 0.75rem;
+  border-radius: 0.75rem;
+  border: 1px solid var(--border);
+}
+
+@media (max-width: 960px) {
+  .layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #0f172a;
+    --fg: #e2e8f0;
+    --card: rgba(15, 23, 42, 0.8);
+    --border: rgba(148, 163, 184, 0.35);
+  }
+
+  .page-header,
+  .page-footer {
+    background: rgba(37, 99, 235, 0.25);
+    border-color: rgba(148, 163, 184, 0.25);
+  }
+
+  .chart-container,
+  .individual-chart {
+    box-shadow: 0 25px 40px -25px rgba(15, 23, 42, 0.8);
+  }
+}


### PR DESCRIPTION
## Summary
- add a FastAPI service that serves a combined API and static client for viewing daily P/E ratios
- compute trailing-twelve-month EPS from Yahoo Finance earnings data with caching and alias handling for TLSA
- implement a Chart.js front-end with multi-select tickers, combined or individual chart modes, and responsive styling

## Testing
- python -m compileall pe_dashboard

------
https://chatgpt.com/codex/tasks/task_e_68f2b0da2b6083209491043be173f512